### PR TITLE
Fixed the cutscenes scene to progress anywhere you click.

### DIFF
--- a/Scare Parts/Assets/UI Toolkit/CutsceneUIVisualTree.uxml
+++ b/Scare Parts/Assets/UI Toolkit/CutsceneUIVisualTree.uxml
@@ -1,6 +1,6 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Assets/UI%20Toolkit/CutsceneStyle.uss?fileID=7433441132597879392&amp;guid=3d9256f4f967ee145b0ad07b044e92cc&amp;type=3#CutsceneStyle" />
     <ui:VisualElement name="Container" style="flex-grow: 1; background-color: rgba(0, 0, 0, 0); overflow: visible;">
-        <ui:Button text="Next" display-tooltip-when-elided="true" name="NextButton" class="button" style="justify-content: flex-start; align-items: auto; align-self: flex-end; -unity-background-image-tint-color: rgb(153, 153, 153); -unity-background-scale-mode: scale-to-fit; visibility: visible; background-color: rgba(0, 0, 0, 0); -unity-text-align: middle-center; display: flex; overflow: visible;" />
+        <ui:Button display-tooltip-when-elided="true" name="NextButton" class="button" style="visibility: visible; display: flex; overflow: visible; margin-left: 0; margin-right: 0; margin-top: 0; margin-bottom: 0; padding-left: 0; padding-right: 0; padding-top: 0; padding-bottom: 0; height: 100%; width: 100%;" />
     </ui:VisualElement>
 </ui:UXML>


### PR DESCRIPTION
This will close #9 

Changes:
- Edited CutsceneUIVisualTree to make the progression button 100% of the width and height always
- This is instead of it being in the top right corner area

Images:
![image](https://github.com/user-attachments/assets/d35ee7d3-2127-4284-aa20-b8294dea03f9)
![image](https://github.com/user-attachments/assets/1e8421aa-6b02-4325-878b-0da4d86b165d)