### PR TITLE
Kgidwani/boost bar

### DIFF
--- a/Scare Parts/Assets/Scripts/GameScreenUIScript.cs
+++ b/Scare Parts/Assets/Scripts/GameScreenUIScript.cs
@@ -14,6 +14,9 @@ public class GameScreenUIScript : MonoBehaviour
     // Reference to the health bar UI element
     private ProgressBar healthBar;
 
+    // Reference to the boost bar UI element
+    private ProgressBar boostBar;
+
 
     // WIP moving health bar is commented out as
     // it was determined to be currently out of scope
@@ -34,16 +37,17 @@ public class GameScreenUIScript : MonoBehaviour
         // Initialize variables
         document = GetComponent<UIDocument>();
         healthBar = document.rootVisualElement.Q("HealthBar") as ProgressBar;
+        boostBar = document.rootVisualElement.Q("BoostBar") as ProgressBar;
     }
 
     // Start is called before the first frame update
     void Start()
     {
-        // Save reference of the inner health bar
-        // This is the part of the bar that moves in response to health
+        // Save reference of the inner bar
+        // This is the part of the bar that will move in response to data changing (health / boost amount)
         VisualElement insideHealthBar = document.rootVisualElement.Q(className: "unity-progress-bar__progress");
 
-        // Change the color of the inner health bar
+        // Change the color of the inner bars
         insideHealthBar.style.backgroundColor = Color.red;
     }
     
@@ -51,6 +55,7 @@ public class GameScreenUIScript : MonoBehaviour
     {
         // Updates bar values
         healthBar.value = playerManager.Health;
+        boostBar.value = playerManager.BoostCurrent;
 
 
         // TODO: Get the health bar to translate accoring to player position
@@ -82,6 +87,5 @@ public class GameScreenUIScript : MonoBehaviour
 
         //healthBar.style.top = playerPositionCorrected.y;
         //healthBar.style.left = playerPositionCorrected.x;
-        
     }
 }

--- a/Scare Parts/Assets/UI Toolkit/GameScreenStyle.uss
+++ b/Scare Parts/Assets/UI Toolkit/GameScreenStyle.uss
@@ -1,4 +1,4 @@
-.HealthBar {
+.VerticalProgressBar {
     width: 250px;
     rotate: -90deg;
     scale: 1 2;
@@ -25,9 +25,9 @@
     top: 95%;
 }
 
-.UIArea {
+.HealthBarArea {
     background-color: rgba(77, 77, 77, 0);
-    width: 33.33%;
+    width: 14%;
     height: 33.33%;
     flex-direction: row-reverse;
     align-self: flex-end;
@@ -54,7 +54,6 @@
 .label {
     font-size: 39px;
     position: absolute;
-    top: 295px;
     -unity-text-align: upper-center;
     -unity-font-style: normal;
     background-color: rgb(77, 77, 77);

--- a/Scare Parts/Assets/UI Toolkit/GameScreenVisualTree 1.uxml
+++ b/Scare Parts/Assets/UI Toolkit/GameScreenVisualTree 1.uxml
@@ -5,7 +5,7 @@
             <ui:Label tabindex="-1" text="Health" display-tooltip-when-elided="true" name="HealthLabel" class="label" style="left: 21%; bottom: 16px;" />
             <ui:ProgressBar value="57" name="HealthBar" class="VerticalProgressBar" style="position: absolute; width: 200px; left: 4%; bottom: 48%;" />
         </ui:VisualElement>
+        <ui:Label tabindex="-1" text="Boost" display-tooltip-when-elided="true" name="BoostLabel" class="label" style="position: absolute; left: 7%; bottom: 16%;" />
+        <ui:ProgressBar name="BoostBar" value="57" class="VerticalProgressBar" style="position: absolute; top: 54%; left: -2%; width: 469px; scale: 1 5;" />
     </ui:VisualElement>
-    <ui:Label tabindex="-1" text="Boost" display-tooltip-when-elided="true" name="BoostLabel" class="label" style="position: absolute; left: 7%; bottom: 16%;" />
-    <ui:ProgressBar name="BoostBar" value="57" class="VerticalProgressBar" style="position: absolute; top: 54%; left: -2%; width: 469px; scale: 1 5;" />
 </ui:UXML>

--- a/Scare Parts/Assets/UI Toolkit/GameScreenVisualTree 1.uxml
+++ b/Scare Parts/Assets/UI Toolkit/GameScreenVisualTree 1.uxml
@@ -1,9 +1,11 @@
 <ui:UXML xmlns:ui="UnityEngine.UIElements" xmlns:uie="UnityEditor.UIElements" xsi="http://www.w3.org/2001/XMLSchema-instance" engine="UnityEngine.UIElements" editor="UnityEditor.UIElements" noNamespaceSchemaLocation="../../UIElementsSchema/UIElements.xsd" editor-extension-mode="False">
     <Style src="project://database/Assets/UI%20Toolkit/GameScreenStyle.uss?fileID=7433441132597879392&amp;guid=a8be1d0712cd84649aa9b3f2eeb10ad5&amp;type=3#GameScreenStyle" />
     <ui:VisualElement name="Container" style="flex-grow: 1; background-color: rgba(0, 0, 0, 0);">
-        <ui:VisualElement name="UIArea" class="UIArea" style="flex-wrap: wrap-reverse; flex-direction: row-reverse; width: 336px; left: 1645px;">
-            <ui:Label tabindex="-1" text="Health" display-tooltip-when-elided="true" name="HealthLabel" class="label" style="left: 55px; position: absolute;" />
-            <ui:ProgressBar value="57" name="HealthBar" class="HealthBar" style="position: absolute; width: 200px; left: 17px;" />
+        <ui:VisualElement name="HealthBarArea" class="HealthBarArea">
+            <ui:Label tabindex="-1" text="Health" display-tooltip-when-elided="true" name="HealthLabel" class="label" style="left: 21%; bottom: 16px;" />
+            <ui:ProgressBar value="57" name="HealthBar" class="VerticalProgressBar" style="position: absolute; width: 200px; left: 4%; bottom: 48%;" />
         </ui:VisualElement>
     </ui:VisualElement>
+    <ui:Label tabindex="-1" text="Boost" display-tooltip-when-elided="true" name="BoostLabel" class="label" style="position: absolute; left: 7%; bottom: 16%;" />
+    <ui:ProgressBar name="BoostBar" value="57" class="VerticalProgressBar" style="position: absolute; top: 54%; left: -2%; width: 469px; scale: 1 5;" />
 </ui:UXML>


### PR DESCRIPTION
Changes:
- Added boost bar UI element to VisualTree per Art Team UI mockup
- Hooked up the boost bar to get updated by player manager

Images:
![image](https://github.com/user-attachments/assets/887b5e7e-1700-46eb-b462-7f92b64acbef)
![image](https://github.com/user-attachments/assets/5a264149-b868-44ee-975f-d2de1b3573b7)

Testing:
- Open game scene
- Press 'b' to charge boost
- Check if bar is filling
- Once full and speed increases, check that the bar lowers again